### PR TITLE
allow systems to specify where their WPA conf is located.

### DIFF
--- a/index.sh
+++ b/index.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 
-WPA_CONF=/etc/wpa_supplicant.conf
+WPA_CONF=${WPA_CONF-/etc/wpa_suppplicant.conf}
 
 # SSID PASSPHRASE
 add () {


### PR DESCRIPTION
On arch the `wpa_supplicant.conf` is located in `/etc/wpa_supplicant/wpa_supplicant.conf`.
